### PR TITLE
[chore] 프레임 송신 API 주소 설정

### DIFF
--- a/app/src/main/java/com/bumper_car/vroomie_fe/ui/screen/drive/NaviActivity.kt
+++ b/app/src/main/java/com/bumper_car/vroomie_fe/ui/screen/drive/NaviActivity.kt
@@ -69,7 +69,7 @@ class NaviActivity : AppCompatActivity(),
         cameraStreamer = CameraStreamer(
             context = this,
             previewView = previewView,
-            wsUrl = "ws://${BuildConfig.SERVER_IP_ADDRESS}:8080"
+            wsUrl = "ws://${BuildConfig.SERVER_IP_ADDRESS}:8080/ws/video"
         )
         cameraStreamer.startWebSocket()
         cameraStreamer.bindCameraWithStream(this)


### PR DESCRIPTION
# #️⃣연관된 이슈
#21

# 📄작업 내용
단순히 서버 주소에 프레임을 보냈던 기존 방식을 지정된 백엔드 주소로 전송
